### PR TITLE
enable/disable binders

### DIFF
--- a/lib/bindings/binders/html/enable.js
+++ b/lib/bindings/binders/html/enable.js
@@ -1,0 +1,25 @@
+(function () {
+  
+  var writeEnable = function writeEnable(view, truthy) {
+    ASSERT(view instanceof jQuery, "expected jQuery object");
+    if (!!truthy) {
+      view.removeAttr("disabled");
+    } else {
+      view.attr("disabled", "disabled");
+    }
+  };
+  
+  hd.binders["enable"] = function bindEnable(view, truthy) {
+    hd.bindWrite(truthy, view, { write: writeEnable });
+  };
+  
+  var writeDisable = function writeDisable(view, truthy) {
+    return writeEnable(view, !truthy);
+  };
+  
+  hd.binders["disable"] = function bindDisable(view, truthy) {
+    hd.bindWrite(truthy, view, { write: writeDisable });
+  };
+
+}());
+

--- a/make/Makefile.lib
+++ b/make/Makefile.lib
@@ -44,6 +44,7 @@ SOURCES := \
   bindings/binders/html/style.js \
   bindings/binders/html/css.js \
   bindings/binders/html/visible.js \
+  bindings/binders/html/enable.js \
   bindings/binders/value/common.js \
   bindings/binders/value/checkbox.js \
   bindings/binders/value/checkboxGroup.js \


### PR DESCRIPTION
I added enable/disable binders so that you can do this:

``` javascript
var Model = hd.model(function Model() {
  this.itemToAdd = hd.variable("");
  // ...
}
var model = new Model;

$(document).ready(function () {
  hd.bind(model);
});
```

``` html
<form data-bind="submit: addItem">
  New item:
  <input data-bind='btb: itemToAdd' />
  <button type="submit" data-bind="enable: itemToAdd">Add</button>
</form>
```
