### PR TITLE
Displaying newlines with text binder

### DIFF
--- a/lib/bindings/binders/html/text.js
+++ b/lib/bindings/binders/html/text.js
@@ -3,8 +3,9 @@
   var write = function writeText(view, value) {
     ASSERT(view instanceof jQuery, "expected jQuery object");
     if (typeof value !== "string") value = JSON.stringify(value);
-    view.text(value);
-    view.html(view.html().replace(/\n/g,"<br />"));
+    /* Encode HTML entities. */
+    value = view.text(value).html();
+    view.html(value.replace(/\n/g,"<br />"));
   };
 
   /* @param option { hd.variable | String } */


### PR DESCRIPTION
The text binder now displays newlines correctly

``` javascript
this.value = hd.variable("Hello,\nthis is a test!");
```

``` html
<span data-bind="text: value"></span>
```

Now displays: 

```
Hello,
this is a test!
```
